### PR TITLE
feat: add honeypot and timing spam protection to booking form

### DIFF
--- a/src/components/Boka.tsx
+++ b/src/components/Boka.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import { makeServerPost } from "../backend-api/utils";
 import styled from "@emotion/styled";
 import TextField from "@mui/material/TextField";
@@ -30,6 +30,15 @@ const VerticalAlignSpan = styled.span`
 const DatePickerWrapper = styled.div`
   width: 150px;
   display: inline-block;
+`;
+
+const HoneypotWrapper = styled.div`
+  position: absolute;
+  left: -10000px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
 `;
 
 interface TextFieldCustProps {
@@ -171,6 +180,16 @@ const BokningForm = ({
           margin="normal"
         />
 
+        <HoneypotWrapper aria-hidden="true">
+          <input
+            type="text"
+            name="website"
+            tabIndex={-1}
+            autoComplete="off"
+            defaultValue=""
+          />
+        </HoneypotWrapper>
+
         <br />
         <br />
         <Button type="submit" variant="contained" color="primary">
@@ -189,6 +208,7 @@ const Boka = () => {
   const [fromDate, handleFromDateChange] = useState<Date | null>(null);
   const [toDate, handleToDateChange] = useState<Date | null>(null);
   const [kanoter, setKanoter] = useState(false);
+  const loadTimeRef = useRef(Date.now());
 
   const isValidEmail = (email: string): boolean =>
     /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
@@ -226,6 +246,8 @@ const Boka = () => {
       from: fromDate ? format(fromDate, "yyyy-MM-dd") : "",
       to: toDate ? format(toDate, "yyyy-MM-dd") : "",
       other: (target.elements.namedItem("other") as HTMLInputElement).value,
+      website: (target.elements.namedItem("website") as HTMLInputElement).value,
+      elapsed_ms: Date.now() - loadTimeRef.current,
     };
 
     makeServerPost("booking.php", body).then(

--- a/src/components/Boka.tsx
+++ b/src/components/Boka.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from "react";
+import React, { useState } from "react";
 import { makeServerPost } from "../backend-api/utils";
 import styled from "@emotion/styled";
 import TextField from "@mui/material/TextField";
@@ -208,7 +208,7 @@ const Boka = () => {
   const [fromDate, handleFromDateChange] = useState<Date | null>(null);
   const [toDate, handleToDateChange] = useState<Date | null>(null);
   const [kanoter, setKanoter] = useState(false);
-  const loadTimeRef = useRef(Date.now());
+  const [loadTime] = useState(() => Date.now());
 
   const isValidEmail = (email: string): boolean =>
     /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
@@ -247,7 +247,7 @@ const Boka = () => {
       to: toDate ? format(toDate, "yyyy-MM-dd") : "",
       other: (target.elements.namedItem("other") as HTMLInputElement).value,
       website: (target.elements.namedItem("website") as HTMLInputElement).value,
-      elapsed_ms: Date.now() - loadTimeRef.current,
+      elapsed_ms: Date.now() - loadTime,
     };
 
     makeServerPost("booking.php", body).then(

--- a/static/api/booking.php
+++ b/static/api/booking.php
@@ -20,6 +20,19 @@ if (isset($_POST)) {
   // Converts it into a PHP object
   $jsonData = json_decode($jsonInput);
 
+  // Spam protection: honeypot field + minimum fill time.
+  // Bots typically fill all fields (including the hidden "website" field) and
+  // submit much faster than a human can fill the form. Return a fake success
+  // so spammers don't retry or probe for the rejection reason.
+  $honeypot = isset($jsonData->website) ? trim((string)$jsonData->website) : '';
+  $elapsedMs = isset($jsonData->elapsed_ms) ? (int)$jsonData->elapsed_ms : 0;
+
+  if ($honeypot !== '' || $elapsedMs < 3000) {
+    header('Content-Type: application/json');
+    echo json_encode(array('sent' => true, 'msg' => ''));
+    return;
+  }
+
   $message = "Bokningsförfrågan från hemsidan. \r\n \r\n" .
   "Organisation: " . $jsonData->organisation . "\r\n" .
   "Namn: " . $jsonData->name . "\r\n" .


### PR DESCRIPTION
## Summary
- Adds a hidden `website` honeypot field and an `elapsed_ms` timestamp to the booking form submission.
- `static/api/booking.php` silently returns success (no email sent) when the honeypot is filled or the form was submitted in under 3 seconds — bots get no signal to retry.

## Test plan
- [x] `npx vitest run src/components/Boka.spec.tsx` — all 6 tests pass.
- [ ] Submit the real booking form on a deployed/staging environment and confirm the email still arrives.
- [ ] Submit with the honeypot pre-filled via devtools and confirm no email arrives but the success message shows.